### PR TITLE
Legger til endepunkt for påbegynte dagpengesøknader

### DIFF
--- a/src/main/kotlin/no/nav/bakveientilarbeid/dagpenger/DagpengerConsumer.kt
+++ b/src/main/kotlin/no/nav/bakveientilarbeid/dagpenger/DagpengerConsumer.kt
@@ -15,9 +15,14 @@ class DagpengerConsumer(private val httpClient: HttpClient) {
         return httpClient.get(VEDTAK_URL, userToken)
     }
 
+    suspend fun hentPabegynteSoknader(userToken: AccessToken): String {
+        return httpClient.get(PABEGYNTE_SOKNADER_URL, userToken)
+    }
+
     companion object {
         private const val DAGPENGER_INNSYN_URL = "http://dp-innsyn.teamdagpenger.svc.cluster.local"
         private val SOKNAD_URL = URL("$DAGPENGER_INNSYN_URL/soknad")
         private val VEDTAK_URL = URL("$DAGPENGER_INNSYN_URL/vedtak")
+        private val PABEGYNTE_SOKNADER_URL = URL("$DAGPENGER_INNSYN_URL/paabegynte")
     }
 }

--- a/src/main/kotlin/no/nav/bakveientilarbeid/dagpenger/DagpengerService.kt
+++ b/src/main/kotlin/no/nav/bakveientilarbeid/dagpenger/DagpengerService.kt
@@ -21,4 +21,10 @@ class DagpengerService(
         val token = hentToken(user)
         return dagpengerConsumer.hentVedtak(token)
     }
+
+    suspend fun hentPabegynteSoknader(user: AuthenticatedUser): String {
+        logger.info("Henter påbegynte søknader for bruker")
+        val token = hentToken(user)
+        return dagpengerConsumer.hentPabegynteSoknader(token)
+    }
 }

--- a/src/main/kotlin/no/nav/bakveientilarbeid/dagpenger/dagpengerApi.kt
+++ b/src/main/kotlin/no/nav/bakveientilarbeid/dagpenger/dagpengerApi.kt
@@ -15,5 +15,9 @@ fun Route.dagpengerApi(dagpengerService: DagpengerService) {
     get("/dagpenger/vedtak") {
         call.respond(HttpStatusCode.OK, dagpengerService.hentVedtak(authenticatedUser).toString())
     }
+
+     get("/dagpenger/paabegynte") {
+        call.respond(HttpStatusCode.OK, dagpengerService.hentPabegynteSoknader(authenticatedUser).toString())
+    }
 }
 


### PR DESCRIPTION
I forbindelse med at vi skal bort fra det gamle saksapiet flytter vi kallet  som henter påbegynte dagpengesøknader fra hendelser og over til dp-innsyn