### PR TITLE
Gjør det mulig å kalle på bakveientilarbeid fra frontend applikasjoner

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-
+      - add-endpoints
 
 env:
   IMAGE_BASE: ghcr.io/${{ github.repository }}/bakveientilarbeid
@@ -56,6 +56,7 @@ jobs:
     name: Deploy to dev
     needs: build-and-publish
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/add-endpoints'
     steps:
       - uses: actions/checkout@v1
 

--- a/nais/dev-gcp/nais.yaml
+++ b/nais/dev-gcp/nais.yaml
@@ -20,7 +20,7 @@ spec:
   tokenx:
     enabled: true
   ingresses:
-    - "https://person.dev.nav.no/bakveientilarbeid"
+    - "https://arbeid.dev.nav.no/bakveientilarbeid"
     - "https://bakveientilarbeid.dev.intern.nav.no/bakveientilarbeid"
   envFrom:
     - configmap: loginservice-idporten

--- a/nais/dev-gcp/nais.yaml
+++ b/nais/dev-gcp/nais.yaml
@@ -28,6 +28,8 @@ spec:
   env:
     - name: CORS_ALLOWED_ORIGINS
       value: dev.nav.no
+    - name: CORS_ALLOWED_SCHEMES
+      value: https
     - name: MELDEKORT_APP_NAME
       value: "meldekort-api-q1"
   resources:

--- a/nais/dev-gcp/nais.yaml
+++ b/nais/dev-gcp/nais.yaml
@@ -21,6 +21,7 @@ spec:
     enabled: true
   webproxy: true
   ingresses:
+    - "https://arbeid.dev.nav.no/bakveientilarbeid"
     - "https://dev.nav.no/bakveientilarbeid"
     - "https://bakveientilarbeid.dev.intern.nav.no/bakveientilarbeid"
   envFrom:

--- a/nais/dev-gcp/nais.yaml
+++ b/nais/dev-gcp/nais.yaml
@@ -20,8 +20,7 @@ spec:
   tokenx:
     enabled: true
   ingresses:
-    - "https://arbeid.dev.nav.no/bakveientilarbeid"
-    - "https://dev.nav.no/bakveientilarbeid"
+    - "https://person.dev.nav.no/bakveientilarbeid"
     - "https://bakveientilarbeid.dev.intern.nav.no/bakveientilarbeid"
   envFrom:
     - configmap: loginservice-idporten

--- a/nais/dev-gcp/nais.yaml
+++ b/nais/dev-gcp/nais.yaml
@@ -31,6 +31,8 @@ spec:
       value: https
     - name: MELDEKORT_APP_NAME
       value: "meldekort-api-q1"
+    - name: PTO_PROXY_URL
+      value: https://pto-proxy.dev.intern.nav.no/proxy
   resources:
     limits:
       cpu: "3"

--- a/nais/dev-gcp/nais.yaml
+++ b/nais/dev-gcp/nais.yaml
@@ -19,7 +19,6 @@ spec:
     max: 4
   tokenx:
     enabled: true
-  webproxy: true
   ingresses:
     - "https://arbeid.dev.nav.no/bakveientilarbeid"
     - "https://dev.nav.no/bakveientilarbeid"

--- a/nais/prod-gcp/nais.yaml
+++ b/nais/prod-gcp/nais.yaml
@@ -35,6 +35,8 @@ spec:
       value: https
     - name: MELDEKORT_APP_NAME
       value: "meldekort-api"
+    - name: PTO_PROXY_URL
+      value: https://pto-proxy.intern.nav.no/proxy
   resources:
     limits:
       cpu: "3"

--- a/nais/prod-gcp/nais.yaml
+++ b/nais/prod-gcp/nais.yaml
@@ -31,6 +31,8 @@ spec:
   env:
     - name: CORS_ALLOWED_ORIGINS
       value: nav.no
+    - name: CORS_ALLOWED_SCHEMES
+      value: https
     - name: MELDEKORT_APP_NAME
       value: "meldekort-api"
   resources:

--- a/src/main/kotlin/no/nav/bakveientilarbeid/config/ApplicationContext.kt
+++ b/src/main/kotlin/no/nav/bakveientilarbeid/config/ApplicationContext.kt
@@ -13,7 +13,7 @@ import no.nav.bakveientilarbeid.ptoproxy.PtoProxyService
 import no.nav.tms.token.support.tokendings.exchange.TokendingsServiceBuilder
 
 class ApplicationContext {
-
+    val environment = Environment()
     val httpClient = HttpClientBuilder.build()
 
     val tokendingsService = TokendingsServiceBuilder.buildTokendingsService(maxCachedEntries = 5000)
@@ -22,7 +22,7 @@ class ApplicationContext {
 
     val dagpengerConsumer = DagpengerConsumer(httpClient)
     val meldekortConsumer = MeldekortConsumer(httpClient)
-    val ptoProxyConsumer = PtoProxyConsumer(httpClient)
+    val ptoProxyConsumer = PtoProxyConsumer(httpClient, environment.ptoProxyUrl)
 
     val healthService = HealthService(this)
     val dagpengerService = DagpengerService(dagpengerConsumer, dagpengerTokendings)

--- a/src/main/kotlin/no/nav/bakveientilarbeid/config/ApplicationContext.kt
+++ b/src/main/kotlin/no/nav/bakveientilarbeid/config/ApplicationContext.kt
@@ -8,6 +8,8 @@ import no.nav.bakveientilarbeid.http.HttpClientBuilder
 import no.nav.bakveientilarbeid.meldekort.MeldekortConsumer
 import no.nav.bakveientilarbeid.meldekort.MeldekortService
 import no.nav.bakveientilarbeid.meldekort.MeldekortTokendings
+import no.nav.bakveientilarbeid.ptoproxy.PtoProxyConsumer
+import no.nav.bakveientilarbeid.ptoproxy.PtoProxyService
 import no.nav.tms.token.support.tokendings.exchange.TokendingsServiceBuilder
 
 class ApplicationContext {
@@ -20,8 +22,10 @@ class ApplicationContext {
 
     val dagpengerConsumer = DagpengerConsumer(httpClient)
     val meldekortConsumer = MeldekortConsumer(httpClient)
+    val ptoProxyConsumer = PtoProxyConsumer(httpClient)
 
     val healthService = HealthService(this)
     val dagpengerService = DagpengerService(dagpengerConsumer, dagpengerTokendings)
     val meldekortService = MeldekortService(meldekortConsumer, meldekortTokendings)
+    val ptoProxyService = PtoProxyService(ptoProxyConsumer);
 }

--- a/src/main/kotlin/no/nav/bakveientilarbeid/config/Environment.kt
+++ b/src/main/kotlin/no/nav/bakveientilarbeid/config/Environment.kt
@@ -2,7 +2,8 @@ package no.nav.bakveientilarbeid.config
 
 
 data class Environment(
-    val corsAllowedOrigins: String = requireProperty("CORS_ALLOWED_ORIGINS")
+    val corsAllowedOrigins: String = requireProperty("CORS_ALLOWED_ORIGINS"),
+    val corsAllowedSchemes: String = requireProperty("CORS_ALLOWED_SCHEMES")
 
 )
 

--- a/src/main/kotlin/no/nav/bakveientilarbeid/config/Environment.kt
+++ b/src/main/kotlin/no/nav/bakveientilarbeid/config/Environment.kt
@@ -3,7 +3,8 @@ package no.nav.bakveientilarbeid.config
 
 data class Environment(
     val corsAllowedOrigins: String = requireProperty("CORS_ALLOWED_ORIGINS"),
-    val corsAllowedSchemes: String = requireProperty("CORS_ALLOWED_SCHEMES")
+    val corsAllowedSchemes: String = requireProperty("CORS_ALLOWED_SCHEMES"),
+    val ptoProxyUrl: String = requireProperty("PTO_PROXY_URL")
 
 )
 

--- a/src/main/kotlin/no/nav/bakveientilarbeid/config/bootstrap.kt
+++ b/src/main/kotlin/no/nav/bakveientilarbeid/config/bootstrap.kt
@@ -12,6 +12,7 @@ import no.nav.bakveientilarbeid.dagpenger.dagpengerRoute
 import no.nav.bakveientilarbeid.health.healthRoute
 import no.nav.bakveientilarbeid.http.jsonConfig
 import no.nav.bakveientilarbeid.meldekort.meldekortRoute
+import no.nav.bakveientilarbeid.ptoproxy.ptoProxyRoute
 import no.nav.personbruker.dittnav.common.security.AuthenticatedUser
 import no.nav.personbruker.dittnav.common.security.AuthenticatedUserFactory
 import no.nav.security.token.support.ktor.tokenValidationSupport
@@ -42,6 +43,7 @@ fun Application.mainModule(appContext: ApplicationContext = ApplicationContext()
         authenticate {
             dagpengerRoute(appContext.dagpengerService)
             meldekortRoute(appContext.meldekortService)
+            ptoProxyRoute(appContext.ptoProxyService)
         }
     }
 

--- a/src/main/kotlin/no/nav/bakveientilarbeid/config/bootstrap.kt
+++ b/src/main/kotlin/no/nav/bakveientilarbeid/config/bootstrap.kt
@@ -23,7 +23,7 @@ fun Application.mainModule(appContext: ApplicationContext = ApplicationContext()
     install(DefaultHeaders)
 
     install(CORS) {
-        host(environment.corsAllowedOrigins)
+        host(environment.corsAllowedOrigins, schemes = listOf(environment.corsAllowedSchemes))
         allowCredentials = true
         header(HttpHeaders.ContentType)
     }

--- a/src/main/kotlin/no/nav/bakveientilarbeid/http/httpClient.kt
+++ b/src/main/kotlin/no/nav/bakveientilarbeid/http/httpClient.kt
@@ -9,6 +9,9 @@ import no.nav.bakveientilarbeid.auth.AccessToken
 import no.nav.tms.token.support.tokendings.exchange.TokenXHeader
 import java.net.URL
 
+const val consumerIdHeaderName = "Nav-Consumer-Id"
+const val consumerIdHeaderValue = "paw:bakveientilarbeid"
+
 suspend inline fun <reified T> HttpClient.get(url: URL, accessToken: AccessToken): T = withContext(Dispatchers.IO) {
     request {
         url("$url")
@@ -23,6 +26,16 @@ suspend inline fun <reified T> HttpClient.getWithTokenX(url: URL, accessToken: A
         header("TokenXAuthorization", "Bearer ${accessToken.value}")
     }
 }
+
+suspend inline fun <reified T> HttpClient.getWithConsumerId(url: URL, accessToken: AccessToken): T = withContext(Dispatchers.IO) {
+    request {
+        url(url)
+        method = HttpMethod.Get
+        header(HttpHeaders.Authorization, "Bearer ${accessToken.value}")
+        header(consumerIdHeaderName, consumerIdHeaderValue)
+    }
+}
+
 suspend inline fun <reified T> HttpClient.post(url: URL): T = withContext(Dispatchers.IO) {
     request {
         url("$url")

--- a/src/main/kotlin/no/nav/bakveientilarbeid/ptoproxy/PtoProxyConsumer.kt
+++ b/src/main/kotlin/no/nav/bakveientilarbeid/ptoproxy/PtoProxyConsumer.kt
@@ -36,7 +36,7 @@ class PtoProxyConsumer(private val httpClient: HttpClient) {
     }
 
     companion object {
-        private const val PTO_PROXY_URL = "https://pto-proxy.dev.intern.nav.no/proxy"
+        private const val PTO_PROXY_URL = "https://pto-proxy.pto.svc.cluster.local/proxy"
         private val OPPFOLGING_URL = URL("$PTO_PROXY_URL/veilarboppfolging/api/oppfolging")
         private val UNDER_OPPFOLGING_URL = URL("$PTO_PROXY_URL/veilarboppfolging/api/niva3/underoppfolging")
         private val START_REGISTRERING_URL = URL("$PTO_PROXY_URL/veilarbregistrering/api/startregistrering")

--- a/src/main/kotlin/no/nav/bakveientilarbeid/ptoproxy/PtoProxyConsumer.kt
+++ b/src/main/kotlin/no/nav/bakveientilarbeid/ptoproxy/PtoProxyConsumer.kt
@@ -23,7 +23,7 @@ class PtoProxyConsumer(private val httpClient: HttpClient) {
         return httpClient.getWithConsumerId(REGISTRERING_URL, userToken)
     }
 
-    suspend fun hentDialog(userToken: AccessToken): String {
+    suspend fun hentUlesteDialoger(userToken: AccessToken): String {
         return httpClient.getWithConsumerId(DIALOG_URL, userToken)
     }
 

--- a/src/main/kotlin/no/nav/bakveientilarbeid/ptoproxy/PtoProxyConsumer.kt
+++ b/src/main/kotlin/no/nav/bakveientilarbeid/ptoproxy/PtoProxyConsumer.kt
@@ -36,7 +36,7 @@ class PtoProxyConsumer(private val httpClient: HttpClient) {
     }
 
     companion object {
-        private const val PTO_PROXY_URL = "http://ptos-proxy.pto.svc.cluster.local/proxy"
+        private const val PTO_PROXY_URL = "http://pto-proxy.pto.svc.cluster.local/proxy"
         private val OPPFOLGING_URL = URL("$PTO_PROXY_URL/veilarboppfolging/api/oppfolging")
         private val UNDER_OPPFOLGING_URL = URL("$PTO_PROXY_URL/veilarboppfolging/api/niva3/underoppfolging")
         private val START_REGISTRERING_URL = URL("$PTO_PROXY_URL/veilarbregistrering/api/startregistrering")

--- a/src/main/kotlin/no/nav/bakveientilarbeid/ptoproxy/PtoProxyConsumer.kt
+++ b/src/main/kotlin/no/nav/bakveientilarbeid/ptoproxy/PtoProxyConsumer.kt
@@ -1,0 +1,48 @@
+package no.nav.bakveientilarbeid.ptoproxy
+
+import io.ktor.client.*
+import no.nav.bakveientilarbeid.auth.AccessToken
+import no.nav.bakveientilarbeid.http.getWithConsumerId
+import java.net.URL
+
+class PtoProxyConsumer(private val httpClient: HttpClient) {
+
+    suspend fun hentOppfolging(userToken: AccessToken): String {
+        return httpClient.getWithConsumerId(OPPFOLGING_URL, userToken)
+    }
+
+    suspend fun hentUnderOppfolging(userToken: AccessToken): String {
+        return httpClient.getWithConsumerId(UNDER_OPPFOLGING_URL, userToken)
+    }
+
+    suspend fun hentStartRegistrering(userToken: AccessToken): String {
+        return httpClient.getWithConsumerId(START_REGISTRERING_URL, userToken)
+    }
+
+    suspend fun hentRegistrering(userToken: AccessToken): String {
+        return httpClient.getWithConsumerId(REGISTRERING_URL, userToken)
+    }
+
+    suspend fun hentDialog(userToken: AccessToken): String {
+        return httpClient.getWithConsumerId(DIALOG_URL, userToken)
+    }
+
+    suspend fun hentBesvarelse(userToken: AccessToken): String {
+        return httpClient.getWithConsumerId(BESVARELSE_URL, userToken)
+    }
+
+    suspend fun hentMotestotte(userToken: AccessToken): String {
+        return httpClient.getWithConsumerId(MOTESTOTTE_URL, userToken)
+    }
+
+    companion object {
+        private const val PTO_PROXY_URL = "https://pto-proxy.dev.intern.nav.no/proxy"
+        private val OPPFOLGING_URL = URL("$PTO_PROXY_URL/veilarboppfolging/api/oppfolging")
+        private val UNDER_OPPFOLGING_URL = URL("$PTO_PROXY_URL/veilarboppfolging/api/niva3/underoppfolging")
+        private val START_REGISTRERING_URL = URL("$PTO_PROXY_URL/veilarbregistrering/api/startregistrering")
+        private val REGISTRERING_URL = URL("$PTO_PROXY_URL/veilarbregistrering/api/registrering")
+        private val DIALOG_URL = URL("$PTO_PROXY_URL/veilarbdialog/api/dialog/antallUleste")
+        private val BESVARELSE_URL = URL("$PTO_PROXY_URL/veilarbvedtakinfo/api/behovsvurdering/besvarelse")
+        private val MOTESTOTTE_URL = URL("$PTO_PROXY_URL/veilaveilarbvedtakinfo/api/motestotte")
+    }
+}

--- a/src/main/kotlin/no/nav/bakveientilarbeid/ptoproxy/PtoProxyConsumer.kt
+++ b/src/main/kotlin/no/nav/bakveientilarbeid/ptoproxy/PtoProxyConsumer.kt
@@ -36,7 +36,7 @@ class PtoProxyConsumer(private val httpClient: HttpClient) {
     }
 
     companion object {
-        private const val PTO_PROXY_URL = "https://pto-proxy.dev.intern.nav.no/proxy"
+        private const val PTO_PROXY_URL = "http://ptos-proxy.pto.svc.cluster.local/proxy"
         private val OPPFOLGING_URL = URL("$PTO_PROXY_URL/veilarboppfolging/api/oppfolging")
         private val UNDER_OPPFOLGING_URL = URL("$PTO_PROXY_URL/veilarboppfolging/api/niva3/underoppfolging")
         private val START_REGISTRERING_URL = URL("$PTO_PROXY_URL/veilarbregistrering/api/startregistrering")

--- a/src/main/kotlin/no/nav/bakveientilarbeid/ptoproxy/PtoProxyConsumer.kt
+++ b/src/main/kotlin/no/nav/bakveientilarbeid/ptoproxy/PtoProxyConsumer.kt
@@ -36,7 +36,7 @@ class PtoProxyConsumer(private val httpClient: HttpClient) {
     }
 
     companion object {
-        private const val PTO_PROXY_URL = "http://pto-proxy.pto.svc.cluster.local/proxy"
+        private const val PTO_PROXY_URL = "https://pto-proxy.dev.intern.nav.no/proxy"
         private val OPPFOLGING_URL = URL("$PTO_PROXY_URL/veilarboppfolging/api/oppfolging")
         private val UNDER_OPPFOLGING_URL = URL("$PTO_PROXY_URL/veilarboppfolging/api/niva3/underoppfolging")
         private val START_REGISTRERING_URL = URL("$PTO_PROXY_URL/veilarbregistrering/api/startregistrering")

--- a/src/main/kotlin/no/nav/bakveientilarbeid/ptoproxy/PtoProxyConsumer.kt
+++ b/src/main/kotlin/no/nav/bakveientilarbeid/ptoproxy/PtoProxyConsumer.kt
@@ -5,7 +5,18 @@ import no.nav.bakveientilarbeid.auth.AccessToken
 import no.nav.bakveientilarbeid.http.getWithConsumerId
 import java.net.URL
 
-class PtoProxyConsumer(private val httpClient: HttpClient) {
+class PtoProxyConsumer(
+    private val httpClient: HttpClient,
+    private val PTO_PROXY_URL: String
+) {
+
+    private val OPPFOLGING_URL = URL("$PTO_PROXY_URL/veilarboppfolging/api/oppfolging")
+    private val UNDER_OPPFOLGING_URL = URL("$PTO_PROXY_URL/veilarboppfolging/api/niva3/underoppfolging")
+    private val START_REGISTRERING_URL = URL("$PTO_PROXY_URL/veilarbregistrering/api/startregistrering")
+    private val REGISTRERING_URL = URL("$PTO_PROXY_URL/veilarbregistrering/api/registrering")
+    private val DIALOG_URL = URL("$PTO_PROXY_URL/veilarbdialog/api/dialog/antallUleste")
+    private val BESVARELSE_URL = URL("$PTO_PROXY_URL/veilarbvedtakinfo/api/behovsvurdering/besvarelse")
+    private val MOTESTOTTE_URL = URL("$PTO_PROXY_URL/veilaveilarbvedtakinfo/api/motestotte")
 
     suspend fun hentOppfolging(userToken: AccessToken): String {
         return httpClient.getWithConsumerId(OPPFOLGING_URL, userToken)
@@ -35,14 +46,4 @@ class PtoProxyConsumer(private val httpClient: HttpClient) {
         return httpClient.getWithConsumerId(MOTESTOTTE_URL, userToken)
     }
 
-    companion object {
-        private const val PTO_PROXY_URL = "https://pto-proxy.dev.intern.nav.no/proxy"
-        private val OPPFOLGING_URL = URL("$PTO_PROXY_URL/veilarboppfolging/api/oppfolging")
-        private val UNDER_OPPFOLGING_URL = URL("$PTO_PROXY_URL/veilarboppfolging/api/niva3/underoppfolging")
-        private val START_REGISTRERING_URL = URL("$PTO_PROXY_URL/veilarbregistrering/api/startregistrering")
-        private val REGISTRERING_URL = URL("$PTO_PROXY_URL/veilarbregistrering/api/registrering")
-        private val DIALOG_URL = URL("$PTO_PROXY_URL/veilarbdialog/api/dialog/antallUleste")
-        private val BESVARELSE_URL = URL("$PTO_PROXY_URL/veilarbvedtakinfo/api/behovsvurdering/besvarelse")
-        private val MOTESTOTTE_URL = URL("$PTO_PROXY_URL/veilaveilarbvedtakinfo/api/motestotte")
-    }
 }

--- a/src/main/kotlin/no/nav/bakveientilarbeid/ptoproxy/PtoProxyConsumer.kt
+++ b/src/main/kotlin/no/nav/bakveientilarbeid/ptoproxy/PtoProxyConsumer.kt
@@ -36,7 +36,7 @@ class PtoProxyConsumer(private val httpClient: HttpClient) {
     }
 
     companion object {
-        private const val PTO_PROXY_URL = "https://pto-proxy.pto.svc.cluster.local/proxy"
+        private const val PTO_PROXY_URL = "https://pto-proxy.dev.intern.nav.no/proxy"
         private val OPPFOLGING_URL = URL("$PTO_PROXY_URL/veilarboppfolging/api/oppfolging")
         private val UNDER_OPPFOLGING_URL = URL("$PTO_PROXY_URL/veilarboppfolging/api/niva3/underoppfolging")
         private val START_REGISTRERING_URL = URL("$PTO_PROXY_URL/veilarbregistrering/api/startregistrering")

--- a/src/main/kotlin/no/nav/bakveientilarbeid/ptoproxy/PtoProxyService.kt
+++ b/src/main/kotlin/no/nav/bakveientilarbeid/ptoproxy/PtoProxyService.kt
@@ -1,0 +1,50 @@
+package no.nav.bakveientilarbeid.ptoproxy
+
+import no.nav.bakveientilarbeid.auth.AccessToken
+import no.nav.personbruker.dittnav.common.security.AuthenticatedUser
+
+class PtoProxyService(private val ptoProxyConsumer: PtoProxyConsumer){
+
+    suspend fun hentOppfolgig(user: AuthenticatedUser): String {
+        val token = AccessToken(user.token)
+
+        return ptoProxyConsumer.hentOppfolging(token)
+    }
+
+    suspend fun hentUnderOppfolging(user: AuthenticatedUser): String {
+        val token = AccessToken(user.token)
+
+        return ptoProxyConsumer.hentUnderOppfolging(token)
+    }
+
+    suspend fun hentStartRegistrering(user: AuthenticatedUser): String {
+        val token = AccessToken(user.token)
+
+        return ptoProxyConsumer.hentStartRegistrering(token)
+    }
+
+    suspend fun hentRegistrering(user: AuthenticatedUser): String {
+        val token = AccessToken(user.token)
+
+        return ptoProxyConsumer.hentRegistrering(token)
+    }
+
+    suspend fun hentDialog(user: AuthenticatedUser): String {
+        val token = AccessToken(user.token)
+
+        return ptoProxyConsumer.hentDialog(token)
+    }
+
+    suspend fun hentBesvarelse(user: AuthenticatedUser): String {
+        val token = AccessToken(user.token)
+
+        return ptoProxyConsumer.hentBesvarelse(token)
+    }
+
+    suspend fun hentMotestotte(user: AuthenticatedUser): String {
+        val token = AccessToken(user.token)
+
+        return ptoProxyConsumer.hentMotestotte(token)
+    }
+
+}

--- a/src/main/kotlin/no/nav/bakveientilarbeid/ptoproxy/PtoProxyService.kt
+++ b/src/main/kotlin/no/nav/bakveientilarbeid/ptoproxy/PtoProxyService.kt
@@ -29,10 +29,10 @@ class PtoProxyService(private val ptoProxyConsumer: PtoProxyConsumer){
         return ptoProxyConsumer.hentRegistrering(token)
     }
 
-    suspend fun hentDialog(user: AuthenticatedUser): String {
+    suspend fun hentUlesteDialoger(user: AuthenticatedUser): String {
         val token = AccessToken(user.token)
 
-        return ptoProxyConsumer.hentDialog(token)
+        return ptoProxyConsumer.hentUlesteDialoger(token)
     }
 
     suspend fun hentBesvarelse(user: AuthenticatedUser): String {

--- a/src/main/kotlin/no/nav/bakveientilarbeid/ptoproxy/ptoProxyRoute.kt
+++ b/src/main/kotlin/no/nav/bakveientilarbeid/ptoproxy/ptoProxyRoute.kt
@@ -25,7 +25,7 @@ fun Route.ptoProxyRoute(ptoProxyService: PtoProxyService) {
     }
 
     get("/dialog/antallUleste") {
-        call.respond(HttpStatusCode.OK, ptoProxyService.hentDialog(authenticatedUser).toString())
+        call.respond(HttpStatusCode.OK, ptoProxyService.hentUlesteDialoger(authenticatedUser).toString())
     }
 
     get("/vedtakinfo/besvarelse") {

--- a/src/main/kotlin/no/nav/bakveientilarbeid/ptoproxy/ptoProxyRoute.kt
+++ b/src/main/kotlin/no/nav/bakveientilarbeid/ptoproxy/ptoProxyRoute.kt
@@ -1,0 +1,41 @@
+package no.nav.bakveientilarbeid.ptoproxy
+
+import io.ktor.application.*
+import io.ktor.http.*
+import io.ktor.response.*
+import io.ktor.routing.*
+import no.nav.bakveientilarbeid.config.authenticatedUser
+
+fun Route.ptoProxyRoute(ptoProxyService: PtoProxyService) {
+
+    get("/oppfolging") {
+        call.respond(HttpStatusCode.OK, ptoProxyService.hentOppfolgig(authenticatedUser).toString())
+    }
+
+    get("/underoppfolging") {
+        call.respond(HttpStatusCode.OK, ptoProxyService.hentUnderOppfolging(authenticatedUser).toString())
+    }
+
+    get("/startregistrering") {
+        call.respond(HttpStatusCode.OK, ptoProxyService.hentStartRegistrering(authenticatedUser).toString())
+    }
+
+    get("/registrering") {
+        call.respond(HttpStatusCode.OK, ptoProxyService.hentRegistrering(authenticatedUser).toString())
+    }
+
+    get("/dialog/antallUleste") {
+        call.respond(HttpStatusCode.OK, ptoProxyService.hentDialog(authenticatedUser).toString())
+    }
+
+    get("/vedtakinfo/besvarelse") {
+        call.respond(HttpStatusCode.OK, ptoProxyService.hentBesvarelse(authenticatedUser).toString())
+    }
+
+    get("/vedtakinfo/motestotte") {
+        call.respond(HttpStatusCode.OK, ptoProxyService.hentMotestotte(authenticatedUser).toString())
+    }
+
+}
+
+


### PR DESCRIPTION
* Gjør det mulig å kalle på bakveientilarbeid fra frontend applikasjoner som benytter seg av Loginservice ved å bruke CORS filteret. 
* Setter opp nye endepunkter mot pto-proxy slik at de kan erstatte proxy oppsettet som gikk gjennom pus-decorator i veientilarbeid.